### PR TITLE
Feature/move modbus slave to secrets

### DIFF
--- a/modbus.yaml
+++ b/modbus.yaml
@@ -11,7 +11,7 @@
     sensors:
     - name: 'AC Consumption L1'
       unit_of_measurement: "W"
-      slave: 100
+      slave: !secret com.victronenergy.system
       address: 817
       data_type: uint16
       scan_interval: 2
@@ -19,7 +19,7 @@
       
     - name: 'Multiplus Grid power'
       unit_of_measurement: "W"
-      slave: 100
+      slave: !secret com.victronenergy.system
       address: 820
       data_type: uint16
       scan_interval: 2
@@ -27,7 +27,7 @@
       
     - name: 'Multiplus Solar power'
       unit_of_measurement: "W"
-      slave: 100
+      slave: !secret com.victronenergy.system
       address: 850
       data_type: uint16
       device_class: power
@@ -35,7 +35,7 @@
     - name: 'ESS Minimum SoC setpoint'
       unit_of_measurement: "%"
       data_type: uint16
-      slave: 100
+      slave: !secret com.victronenergy.system
       address: 2901
       scan_interval: 3
       scale: 0.1
@@ -43,16 +43,16 @@
     - name: 'Maximum System Grid Feed In'
       unit_of_measurement: "W"
       data_type: uint16
-      slave: 100
+      slave: !secret com.victronenergy.system
       address: 2706
       device_class: power
       # command_on: 4000
       # command_off: 40
       # verify_state: false
-#Battery 
+#Battery
     - name: 'Battery current'
       unit_of_measurement: "A DC"
-      slave: 100
+      slave: !secret com.victronenergy.system
       address: 841
       data_type: int16
       scale: 0.1
@@ -61,7 +61,7 @@
       
     - name: 'Battery Power System'
       unit_of_measurement: "W"
-      slave: 100
+      slave: !secret com.victronenergy.system
       address: 842
       data_type: int16
       scale: 1.0
@@ -70,7 +70,7 @@
 
     - name: 'Charge Power System'
       unit_of_measurement: "W"
-      slave: 100
+      slave: !secret com.victronenergy.system
       address: 860
       data_type: int16
       scale: 10.0
@@ -79,7 +79,7 @@
       
     - name: 'Battery State of Charge System'
       unit_of_measurement: "%"
-      slave: 100
+      slave: !secret com.victronenergy.system
       address: 843
       data_type: uint16
       scale: 1
@@ -89,7 +89,7 @@
 # Victron device over Modbus: Pylontch Battery slave: 225
     - name: 'Battery current Pylon'
       unit_of_measurement: "A DC"
-      slave: 225
+      slave: !secret com.victronenergy.battery
       address: 261
       data_type: int16
       scale: 0.1
@@ -98,7 +98,7 @@
       
     - name: 'Battery State of Charge'
       unit_of_measurement: "%"
-      slave: 225
+      slave: !secret com.victronenergy.battery
       address: 266
       data_type: int16
       scale: 0.1
@@ -108,7 +108,7 @@
 # Victron device over Modbus: vebus
     - name: 'Multiplus Critical Loads'
       unit_of_measurement: "W"
-      slave: 246
+      slave: !secret com.victronenergy.vebus
       address: 23
       data_type: int16
       scan_interval: 2
@@ -118,7 +118,7 @@
       
     - name: 'Grid Voltage L1 in'
       unit_of_measurement: "V AC"
-      slave: 246
+      slave: !secret com.victronenergy.vebus
       address: 3
       data_type: uint16
       scale: 0.1
@@ -128,8 +128,8 @@
       
     - name: 'Multi Voltage L1 out'
       unit_of_measurement: "V AC"
-      slave: 246
-      address: 15      
+      slave: !secret com.victronenergy.vebus
+      address: 15
       data_type: uint16
       scale: 0.1
       offset: 0
@@ -139,7 +139,7 @@
       #  com.victronenergy.solarcharger slave: 247
     - name: 'Solar Yield today'
       unit_of_measurement: "kWh"
-      slave: 247
+      slave: !secret com.victronenergy.solarcharger
       address: 784
       data_type: uint16
       scale: 0.1
@@ -147,40 +147,40 @@
       
     - name: 'Solar Yield yesterday'
       unit_of_measurement: "kWh"
-      slave: 247
+      slave: !secret com.victronenergy.solarcharger
       address: 786
-      data_type: uint16 
+      data_type: uint16
       scale: 0.1
       precision: 1
       device_class: energy
       
     - name: "Multi Inverter State"
-      slave: 246
+      slave: !secret com.victronenergy.vebus
       address: 31
       data_type: uint16
-      # Inverter States, 0=Off;1=Low Power;2=Fault;3=Bulk;4=Absorption;5=Float;6=Storage;7=Equalize;8=Passthru;9=Inverting;10=Power assist;11=Power supply;252=Bulk protection   
+      # Inverter States, 0=Off;1=Low Power;2=Fault;3=Bulk;4=Absorption;5=Float;6=Storage;7=Equalize;8=Passthru;9=Inverting;10=Power assist;11=Power supply;252=Bulk protection
 
 #Alarm Sensors
     - name: 'Grid lost alarm'
-      slave: 246
+      slave: !secret com.victronenergy.vebus
       address: 64
       data_type: uint16
       unit_of_measurement: "0=Ok;1=Warning"
       
     - name: 'Multi Temperature alarm'
-      slave: 246
+      slave: !secret com.victronenergy.vebus
       address: 34
       data_type: uint16
       unit_of_measurement: "0=Ok;1=Warning;2=Alarm"
       
     - name: 'Multi Overload alarm'
-      slave: 246
+      slave: !secret com.victronenergy.vebus
       address: 36
       data_type: uint16
       unit_of_measurement: "0=Ok;1=Warning;2=Alarm"
 
     - name: 'CCGX Relay Boiler'
-      slave: 100
+      slave: !secret com.victronenergy.system
       address: 806
       data_type: uint16
       unit_of_measurement: "1=Off;0=Heat"

--- a/secrets.yaml
+++ b/secrets.yaml
@@ -2,3 +2,9 @@
 # Use this file to store secrets like usernames and passwords.
 # Learn more at https://www.home-assistant.io/docs/configuration/secrets/
 some_password: welcome
+# victron
+com.victronenergy.grid: 30
+com.victronenergy.system: 100
+com.victronenergy.battery: 225 #245
+com.victronenergy.vebus: 246  #242
+com.victronenergy.solarcharger: 247 # en 100 ?

--- a/secrets.yaml
+++ b/secrets.yaml
@@ -5,6 +5,6 @@ some_password: welcome
 # victron
 com.victronenergy.grid: 30
 com.victronenergy.system: 100
-com.victronenergy.battery: 225 #245
-com.victronenergy.vebus: 246  #242
-com.victronenergy.solarcharger: 247 # en 100 ?
+com.victronenergy.battery: 225
+com.victronenergy.vebus: 246
+com.victronenergy.solarcharger: 247


### PR DESCRIPTION
Hi Lucas

Here is an enhancement if you want. 
It uses the secrets file to store all the slave addresses in one place allowing you to e.g. change all the vebus slave addresses with one change.

I will understand if you don't like this approach... I makes it a lot easier for someone like me to use your config and just edit the values easily
 
`com.victronenergy.grid: 30
com.victronenergy.system: 100
com.victronenergy.battery: 225
com.victronenergy.vebus: 246
com.victronenergy.solarcharger: 247
`

https://github.com/lucode/home-assistant/issues/1